### PR TITLE
add ALCOR patch, missing close bracket

### DIFF
--- a/GameData/kPM/Library/Patches/Patch.cfg
+++ b/GameData/kPM/Library/Patches/Patch.cfg
@@ -56,3 +56,49 @@
 			}
         }
 	}
+}
+
+@PROP[ALCORMFD40x20]:NEEDS[kOS|kOSPropMonitor|ASET]:FINAL
+{
+    @MODULE[RasterPropMonitor]
+	{
+        //Make All Buttons Except G Global
+        @globalButtons = button_UP,button_DOWN,button_ENTER,button_ESC,button_HOME,button_RIGHT,button_LEFT,buttonR9,buttonR10, button_STBY, buttonR1, buttonR2, buttonR3, buttonR4, buttonR5, buttonR6, buttonR7, button_A, button_B, button_C, button_D, button_E, button_F
+            
+        //kOS Page Definition
+		PAGE
+        {
+            //Main
+            name = kOSRPMPage
+			button = button_G
+            textureURL = kPM/Library/Textures/kPM40x20Alt            
+            
+            disableSwitchingTo=pALCORSTBY40x20,pALCORPFD40x20,pTargetMenu40x20,DPAI,pALCORMapOrbit40x20,pALCORMapLanding40x20,pAutopilot40x20,ALCORGraphAltAtmAltDynPressAtm40x20,ALCORGraphTerrainHeightScaner40x20,vesselView,pALCORAscDes40x20,pALCORLanding40x20,pALCORorbit40x20,pALCORorbitDisplay40x20,JSIOrbitDisplay,pALCORDocking40x20,pALCORDocking40x20cross,pALCORshipinfo40x20,pFlightLog40x20,pALCORCrew40x20,pALCORExtCam40x20,pExtCam-1-40x20
+            
+			PAGEHANDLER
+			{
+                //Class name is kOS Monitor
+				name = kOSMonitor
+                
+                //This is the terminal template
+                template = kPM/Library/Terminals/terminal40x20.txt
+				
+                //Processors are named sanely
+				method = ContentProcessor
+                buttonClickMethod = ButtonProcessor
+                
+                //Labels
+                buttonEmptyLabel = LABEL
+                flagEmptyLabel = FLAG
+                
+                //kOSProcessor TermWindow
+				consoleWidth = 40
+				consoleHeight = 15
+                
+                //Text Tint
+                textTint = [#009900ff]
+                textTintUnpowered = [#ffffff3e]
+			}
+        }
+	}
+}


### PR DESCRIPTION
Hi, with this change I added ALCOR 40x20 monitor support and a missing bracket in the process. I don't add a home page because ALCOR's one it's already saturated. Here in action:
![cap](https://cloud.githubusercontent.com/assets/2772168/25669778/e23719a2-302a-11e7-8c13-7887db11eb1f.png)
